### PR TITLE
Match container name to role by contains instead of exact match

### DIFF
--- a/src/nicer-accounts.js
+++ b/src/nicer-accounts.js
@@ -95,14 +95,14 @@ function selectNextRole(backwards) {
 
 function selectRole(roleName) {
     var matchingRolesElements = [...document.querySelectorAll(".saml-role")].filter(
-        div => div.querySelector("label.saml-role-description").textContent.toLowerCase().substring(0, 25) == roleName
+        div => div.querySelector("label.saml-role-description").textContent.toLowerCase().includes(roleName)
     );
     if (matchingRolesElements.length == 0) {
-        console.warning("No role with name " + roleName + " found");
+        console.warning("No role containing " + roleName + " found");
         return false;
     }
     if (matchingRolesElements.length > 1) {
-        console.warning("Multiple roles with prefix " + roleName + " found");
+        console.warning("Multiple roles containing " + roleName + " found");
         return false;
     }
 


### PR DESCRIPTION
This allows for:
 - matching roles if multiple roles with the same first 25 characters exist
 - nicer container names while still matching to roles